### PR TITLE
Priority SOCD

### DIFF
--- a/config/mode_selection.hpp
+++ b/config/mode_selection.hpp
@@ -38,7 +38,7 @@ void select_mode(CommunicationBackend *backend) {
         if (inputs.l) {
             set_mode(backend, new MultiVersusLBXFurd(socd::SOCD_2IP));
         } else if (inputs.left) {
-            set_mode(backend, new FgcMode(socd::SOCD_NEUTRAL));
+            set_mode(backend, new FgcMode(socd::SOCD_PRIORITY));
         } else if (inputs.down) {
             set_mode(backend, new Melee20Button(socd::SOCD_2IP_NO_REAC));
         } else if (inputs.right) {

--- a/include/core/socd.hpp
+++ b/include/core/socd.hpp
@@ -11,11 +11,31 @@ namespace socd {
         SOCD_2IP,
         SOCD_2IP_NO_REAC,
         SOCD_KEYBOARD,
+        SOCD_PRIORITY,
     } SocdType;
 
-    typedef struct {
+    typedef struct SocdPair {
+        SocdPair() : prioritize_input_1(false) {}
+
+        SocdPair(bool InputState::*input_dir1, bool InputState::*input_dir2)
+            : prioritize_input_1(false) {
+            this->input_dir1 = input_dir1;
+            this->input_dir2 = input_dir2;
+        }
+
+        SocdPair(
+            bool InputState::*input_dir1,
+            bool InputState::*input_dir2,
+            bool prioritize_input_1
+        ) {
+            this->input_dir1 = input_dir1;
+            this->input_dir2 = input_dir2;
+            this->prioritize_input_1 = prioritize_input_1;
+        }
+
         bool InputState::*input_dir1;
         bool InputState::*input_dir2;
+        bool prioritize_input_1;
     } SocdPair;
 
     typedef struct {
@@ -31,6 +51,7 @@ namespace socd {
 
     void neutral(bool &input_dir1, bool &input_dir2);
 
+    void priority(bool &input_dir1, bool &input_dir2, bool prioritize_input_1);
 }
 
 #endif

--- a/src/core/InputMode.cpp
+++ b/src/core/InputMode.cpp
@@ -39,6 +39,13 @@ void InputMode::HandleSocd(InputState &inputs) {
                     _socd_states[i]
                 );
                 break;
+            case socd::SOCD_PRIORITY:
+                socd::priority(
+                    inputs.*(pair.input_dir1),
+                    inputs.*(pair.input_dir2),
+                    pair.prioritize_input_1
+                );
+                break;
             case socd::SOCD_KEYBOARD:
                 break;
         }

--- a/src/core/socd.cpp
+++ b/src/core/socd.cpp
@@ -80,3 +80,18 @@ void socd::neutral(bool &input_dir1, bool &input_dir2) {
     input_dir1 = is_dir1;
     input_dir2 = is_dir2;
 }
+
+void socd::priority(bool &input_dir1, bool &input_dir2, bool prioritize_input_1) {
+    bool is_dir1 = false;
+    bool is_dir2 = false;
+    if (!input_dir1 && input_dir2) {
+        is_dir1 = false;
+        is_dir2 = true;
+    }
+    if ((input_dir1 && !input_dir2) || (input_dir1 && input_dir2 && prioritize_input_1)) {
+        is_dir1 = true;
+        is_dir2 = false;
+    }
+    input_dir1 = is_dir1;
+    input_dir2 = is_dir2;
+}

--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -3,7 +3,8 @@
 FgcMode::FgcMode(socd::SocdType socd_type) : ControllerMode(socd_type) {
     _socd_pair_count = 1;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left, &InputState::right},
+        socd::SocdPair{&InputState::left, &InputState::right, false},
+        socd::SocdPair{ &InputState::up,  &InputState::down,  true },
     };
 }
 


### PR DESCRIPTION
Allows different key combinations to prioritize the input in slot 1 of the SocdPair.

This allows a user to prioritize Up over Down, akin to the SOCD resolution of the Hitbox but can be used for any combination of SocdPairs.